### PR TITLE
Fixed including all files when no argument is passed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ async function run() {
 
   try {
     const output = await runFlow(flow, {
-      includeFiles: argv._,
+      includeFiles: argv._.length === 0 ? ['*'] : argv._,
       ignoreFiles,
       options: process.argv
         .slice(2)


### PR DESCRIPTION
When no specific files to include where passed, it never reported any error for any file.

Signed-off-by: Henri Beck <henribeck.dev@gmail.com>